### PR TITLE
quote instead of delete

### DIFF
--- a/superflore/generators/ebuild/ebuild.py
+++ b/superflore/generators/ebuild/ebuild.py
@@ -126,7 +126,7 @@ class Ebuild(object):
         self.name = None
         self.has_patches = False
         self.die_msg = None
-        self.illegal_desc_chars = '()[]{}?*+-|^$\\.#\t\n\r\v\f\'\"'
+        self.illegal_desc_chars = '()[]{}|^$\\#\t\n\r\v\f\'\"\`'
 
     def add_build_depend(self, depend, internal=True):
         if depend in self.rdepends:

--- a/superflore/utils.py
+++ b/superflore/utils.py
@@ -16,6 +16,7 @@
 def sanitize_string(string, illegal_chars):
     ret = str()
     for c in string:
-        if c not in illegal_chars:
-            ret += c
+        if c in illegal_chars:
+            ret += '\\'
+        ret += c
     return ret


### PR DESCRIPTION
Deleting some characters lead to shitty looking descriptions.
Illegal characters can be reduced further to
```
"'`
```
only